### PR TITLE
Remove unnecessary `Copy` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
+### 0.1.5
+
+Remove unnecessary `Copy` trait.
+
+* API Change: [#3](https://github.com/hibariya/pty-rs/pull/3)
+  * Mark `Child#pty` as private, add public `Child#pty()`.
+  * Remove `Copy` trait from `Child` and `ChildPTY`.
+  * Remove `ChildPTY#fd()`, impl `AsRawFd` for `ChildPTY`.
+
 ### 0.1.4
 
-* API Change: [#2](https://github.com/hibariya/pty-rs/pull/2) Make pty::fork() return a single value.
+* API Change: [#2](https://github.com/hibariya/pty-rs/pull/2) Make `pty::fork()` return a single value.
 
 ### 0.1.3
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This function returns `pty::Child`. It represents the child process and its PTY.
 let mut child = pty::fork();
 
 {
-  let mut pty = child.pty.as_mut().unwrap();
+  let mut pty = child.pty_mut().unwrap();
 
   // do something with pty
 }
@@ -62,7 +62,7 @@ fn main()
             else {
                 // Read output via PTY master
                 let mut output     = String::new();
-                let mut pty_master = child.pty.as_mut().unwrap();
+                let mut pty_master = child.pty_mut().unwrap();
 
                 match pty_master.read_to_string(&mut output) {
                     Ok(_nread)  => println!("child tty is: {}", output.trim()),

--- a/README.md
+++ b/README.md
@@ -27,18 +27,6 @@ extern crate pty;
 
 This function returns `pty::Child`. It represents the child process and its PTY.
 
-```rust
-let mut child = pty::fork();
-
-{
-  let mut pty = child.pty_mut().unwrap();
-
-  // do something with pty
-}
-
-child.wait();
-```
-
 For example, the following code spawns `tty(1)` command by `pty::fork()` and outputs the result of the command.
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -25,11 +25,18 @@ extern crate pty;
 
 ### pty::fork()
 
-This function returns `pty::Child`. It knows about the child process and its PTY.
+This function returns `pty::Child`. It represents the child process and its PTY.
 
 ```rust
-let child   = pty::fork();
-let mut pty = child.pty.unwrap();
+let mut child = pty::fork();
+
+{
+  let mut pty = child.pty.as_mut().unwrap();
+
+  // do something with pty
+}
+
+child.wait();
 ```
 
 For example, the following code spawns `tty(1)` command by `pty::fork()` and outputs the result of the command.
@@ -45,7 +52,7 @@ use std::ptr;
 fn main()
 {
     match pty::fork() {
-        Ok(child) => {
+        Ok(mut child) => {
             if child.pid() == 0 {
                 // Child process just exec `tty`
                 let mut ptrs = [CString::new("tty").unwrap().as_ptr(), ptr::null()];
@@ -55,15 +62,15 @@ fn main()
             else {
                 // Read output via PTY master
                 let mut output     = String::new();
-                let mut pty_master = child.pty.unwrap();
+                let mut pty_master = child.pty.as_mut().unwrap();
 
                 match pty_master.read_to_string(&mut output) {
                     Ok(_nread)  => println!("child tty is: {}", output.trim()),
                     Err(e)      => panic!("read error: {}", e)
                 }
-
-                child.wait();
             }
+
+            child.wait();
         },
         Err(e) => panic!("pty::fork error: {}", e)
     }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ use std::ptr;
 fn main()
 {
     match pty::fork() {
-        Ok(mut child) => {
+        Ok(child) => {
             if child.pid() == 0 {
                 // Child process just exec `tty`
                 let mut ptrs = [CString::new("tty").unwrap().as_ptr(), ptr::null()];
@@ -50,15 +50,15 @@ fn main()
             else {
                 // Read output via PTY master
                 let mut output     = String::new();
-                let mut pty_master = child.pty_mut().unwrap();
+                let mut pty_master = child.pty().unwrap();
 
                 match pty_master.read_to_string(&mut output) {
                     Ok(_nread)  => println!("child tty is: {}", output.trim()),
                     Err(e)      => panic!("read error: {}", e)
                 }
-            }
 
-            child.wait();
+                child.wait();
+            }
         },
         Err(e) => panic!("pty::fork error: {}", e)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,12 +27,8 @@ impl Child {
         self.pid
     }
 
-    pub fn pty(&self) -> Option<&ChildPTY> {
-        self.pty.as_ref()
-    }
-
-    pub fn pty_mut(&mut self) -> Option<&mut ChildPTY> {
-        self.pty.as_mut()
+    pub fn pty(&self) -> Option<ChildPTY> {
+        self.pty.clone()
     }
 
     pub fn wait(&self) -> i32 {
@@ -167,7 +163,7 @@ mod tests {
 
     #[test]
     fn it_fork_with_new_pty() {
-        let mut child = fork().unwrap();
+        let child = fork().unwrap();
 
         if child.pid() == 0 {
             let mut ptrs = [CString::new("tty").unwrap().as_ptr(), ptr::null()];
@@ -175,7 +171,7 @@ mod tests {
             unsafe { libc::execvp(*ptrs.as_ptr(), ptrs.as_mut_ptr()) };
         }
         else {
-            let mut pty    = child.pty_mut().unwrap();
+            let mut pty    = child.pty().unwrap();
             let mut string = String::new();
 
             match pty.read_to_string(&mut string) {
@@ -205,7 +201,7 @@ mod tests {
 
     #[test]
     fn it_can_read_write() {
-        let mut child = fork().unwrap();
+        let child = fork().unwrap();
 
         if child.pid() == 0 {
             let mut ptrs = [CString::new("bash").unwrap().as_ptr(), ptr::null()];
@@ -215,7 +211,7 @@ mod tests {
             unsafe { libc::execvp(*ptrs.as_ptr(), ptrs.as_mut_ptr()) };
         }
         else {
-            let mut pty = child.pty_mut().unwrap();
+            let mut pty = child.pty().unwrap();
             let _       = pty.write("echo readme!\n".to_string().as_bytes());
 
             let mut string = String::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ impl Child {
         self.pty.as_mut()
     }
 
-    pub fn wait(&mut self) -> i32 {
+    pub fn wait(&self) -> i32 {
         let mut status = 0 as libc::c_int;
 
         unsafe { libc::waitpid(self.pid, &mut status, 0) };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate libc;
 
 use std::io::{self, Read, Write};
+use std::os::unix::io::{AsRawFd, RawFd};
 
 mod ffi;
 
@@ -49,10 +50,14 @@ impl Child {
 }
 
 impl ChildPTY {
-    pub fn fd(&self) -> libc::c_int { self.fd }
-
     pub fn close(&self) {
-        unsafe { libc::close(self.fd) };
+        unsafe { libc::close(self.as_raw_fd()) };
+    }
+}
+
+impl AsRawFd for ChildPTY {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
     }
 }
 


### PR DESCRIPTION
* Mark `Child#pty` as private, add public `Child#pty()`.
* Remove `Copy` trait from `Child` and `ChildPTY`.
* Remove `ChildPTY#fd()`, impl `AsRawFd` for `ChildPTY`.
