### PR TITLE
Improve error representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.1.6
+
+* [#5](https://github.com/hibariya/pty-rs/pull/5) Improve error representation
+
 ### 0.1.5
 
 * API Change: [#3 Remove unnecessary `Copy` trait](https://github.com/hibariya/pty-rs/pull/3)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ['pty', 'tty', 'pseudo', 'terminal', 'fork']
 
 [dependencies]
 libc = '0.1'
-nix = '*'
+nix = '0.4'
 clippy = {version = '*', optional = true}
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub type Result<T> = result::Result<T, Error>;
 impl std::error::Error for Error {
     fn description(&self) -> &str {
         match *self {
-            Error::Sys(n) => errno::from_i32(n).desc()
+            Error::Sys(n) => errno::from_i32(n).desc(),
         }
     }
 }
@@ -122,8 +122,8 @@ impl Read for ChildPTY {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let nread = unsafe {
             libc::read(self.fd,
-               buf.as_mut_ptr() as *mut libc::c_void,
-               buf.len() as libc::size_t)
+                       buf.as_mut_ptr() as *mut libc::c_void,
+                       buf.len() as libc::size_t)
         };
 
         if nread < 0 {
@@ -138,9 +138,8 @@ impl Write for ChildPTY {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let ret = unsafe {
             libc::write(self.fd,
-                buf.as_ptr() as *const libc::c_void,
-                buf.len() as libc::size_t
-            )
+                        buf.as_ptr() as *const libc::c_void,
+                        buf.len() as libc::size_t)
         };
 
         if ret < 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ impl From<::nix::Error> for Error {
     }
 }
 
-pub fn last_error() -> Error {
+fn last_error() -> Error {
     Error::from(errno::errno())
 }
 


### PR DESCRIPTION
I've added `pty::Error` and `pty::Result` and changed some return values.

* Replace `std::result::Result<(), &str>` with `pty::Result`.
* Replace C function value with `pty::Result`.

As a result, return value of `pty::fork`, `pty::Child#wait()` and `pty::ChildPTY#close()` have been changed.