### PR TITLE
Fix the examples and remove a unused dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pty"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Hika Hibariya <hibariya@gmail.com>"]
 repository = "https://github.com/hibariya/pty-rs"
 homepage = "https://github.com/hibariya/pty-rs"
@@ -16,14 +16,11 @@ unstable      = [] # for building with unstable features on stable Rust
 debug         = [] # for building with debug messages
 travis        = ["lints", "nightly"] # for building with travis-cargo
 
-[dependencies.chan]
-version       = "0.1.18"
-
 [dependencies.errno]
 version       = "*"
 
 [dependencies.libc]
-version       = "*"
+version       = "0.2"
 
 [dependencies.clippy]
 version       = "*"


### PR DESCRIPTION
My [initialization of table](https://github.com/hibariya/pty-rs/compare/master...adjivas:master#diff-b7d6223ce956fb4d563a72305e28f0afL42) for _main_'s example and _it_fork_with_new_pty_'s test hasn't a "null character" of end, it's why I created this pull request, to fix this pass for OSX.
