### PR TITLE
Fix the sample in the README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ fn main() {
   }
   else {
     // Child process just exec `tty`
-    let cmd  = CString::new("tty").unwrap().as_ptr();
-    let args = [cmd, ptr::null()].as_mut_ptr();
+    let cmd  = CString::new("tty").unwrap();
+    let args = [cmd.as_ptr(), ptr::null()].as_mut_ptr();
 
-    unsafe { libc::execvp(cmd, args) };
+    unsafe { libc::execvp(cmd.as_ptr(), args) };
   }
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,10 +66,10 @@
 //!   }
 //!   else {
 //!     // Child process just exec `tty`
-//!     let cmd  = CString::new("tty").unwrap().as_ptr();
-//!     let args = [cmd, ptr::null()].as_mut_ptr();
+//!     let cmd  = CString::new("tty").unwrap();
+//!     let args = [cmd.as_ptr(), ptr::null()].as_mut_ptr();
 //!
-//!     unsafe { libc::execvp(cmd, args) };
+//!     unsafe { libc::execvp(cmd.as_ptr(), args) };
 //!   }
 //! }
 //! ```


### PR DESCRIPTION
This pattern is not correct, because the CString will be freed
immediately after the expression is evaluated:

    let ptr = CString::new("tty").unwrap().as_ptr()

The fix is to hold a reference to the CString while the ptr is used.

See: https://doc.rust-lang.org/std/ffi/struct.CString.html#method.as_ptr