### PR TITLE
Fix test "it_can_read_write" and other issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: rust
-rust: 
+rust:
   - nightly
   - stable
   - beta
@@ -29,4 +29,4 @@ os:
 
 script:
   - cargo build --verbose
-  - cargo test
+  - cargo test --verbose -- --nocapture

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ os:
 
 script:
   - cargo build --verbose
-  - cargo test --verbose -- --nocapture
+  - cargo test

--- a/README.md
+++ b/README.md
@@ -65,10 +65,7 @@ fn main() {
   }
   else {
     // Child process just exec `tty`
-    let cmd  = CString::new("tty").unwrap().as_ptr();
-    let args = [cmd, ptr::null()].as_mut_ptr();
-
-    unsafe { libc::execvp(cmd, args) };
+    Command::new("tty").status().expect("could not execute tty");
   }
 }
 ```

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -3,9 +3,8 @@ extern crate libc;
 extern crate errno;
 
 use pty::fork::*;
-use std::ffi;
 use std::io::Read;
-use std::ptr;
+use std::process::{Command};
 
 fn main() {
     let fork = Fork::from_ptmx().unwrap();
@@ -20,15 +19,6 @@ fn main() {
         }
     } else {
         // Child process just exec `tty`
-        let cmd = ffi::CString::new("tty").unwrap();
-        let mut args: Vec<*const libc::c_char> = Vec::with_capacity(1);
-
-        args.push(cmd.as_ptr());
-        args.push(ptr::null());
-        unsafe {
-            if libc::execvp(cmd.as_ptr(), args.as_mut_ptr()).eq(&-1) {
-                panic!("{}: {}", cmd.to_string_lossy(), ::errno::errno());
-            }
-        };
+        Command::new("tty").status().expect("could not execute tty");
     }
 }

--- a/examples/new.rs
+++ b/examples/new.rs
@@ -3,12 +3,8 @@ extern crate libc;
 
 use self::pty::prelude::*;
 
-use std::ffi::CString;
-
 use std::io::prelude::*;
 use std::process::{Command, Stdio};
-use std::ptr;
-use std::string::String;
 
 fn main() {
     let fork = Fork::from_ptmx().unwrap();
@@ -23,8 +19,9 @@ fn main() {
             .output()
             .unwrap()
             .stdout;
+        let output_str = String::from_utf8_lossy(&output);
 
-        let parent_tty = String::from_utf8_lossy(&output);
+        let parent_tty = output_str.trim();
         let child_tty = string.trim();
 
         println!("child_tty(\"{}\")[{}] != \"{}\" => {}", child_tty, child_tty.len(), "", child_tty != "");
@@ -39,7 +36,6 @@ fn main() {
 
         assert_eq!(parent_tty_dir, child_tty_dir);
     } else {
-        let mut ptrs = [CString::new("tty").unwrap().as_ptr(), ptr::null()];
-        let _ = unsafe { libc::execvp(*ptrs.as_ptr(), ptrs.as_mut_ptr()) };
+        let _ = Command::new("tty").status();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! use std::ffi::CString;
 //! use std::io::Read;
-//! use std::ptr;
+//! use std::process::{Command};
 //!
 //! use pty::fork::*;
 //!
@@ -66,10 +66,7 @@
 //!   }
 //!   else {
 //!     // Child process just exec `tty`
-//!     let cmd  = CString::new("tty").unwrap().as_ptr();
-//!     let args = [cmd, ptr::null()].as_mut_ptr();
-//!
-//!     unsafe { libc::execvp(cmd, args) };
+//!     Command::new("tty").status().expect("could not execute tty");
 //!   }
 //! }
 //! ```

--- a/tests/it_can_read_write.rs
+++ b/tests/it_can_read_write.rs
@@ -4,7 +4,7 @@ extern crate libc;
 use std::io::prelude::*;
 use std::string::String;
 use std::process::Command;
-use pty::fork::{Fork, Master};
+use self::pty::fork::{Fork, Master};
 
 fn read_line(master:&mut Master) -> String {
     let mut buf = [0];

--- a/tests/it_can_read_write.rs
+++ b/tests/it_can_read_write.rs
@@ -1,10 +1,11 @@
 extern crate pty;
 extern crate libc;
 
+use self::pty::prelude::*;
+
 use std::io::prelude::*;
 use std::string::String;
 use std::process::Command;
-use self::pty::fork::{Fork, Master};
 
 fn read_line(master:&mut Master) -> String {
     let mut buf = [0];

--- a/tests/it_fork_with_new_pty.rs
+++ b/tests/it_fork_with_new_pty.rs
@@ -25,21 +25,26 @@ fn it_fork_with_new_pty() {
             .output()
             .unwrap()
             .stdout;
+        let output_str = String::from_utf8_lossy(&output);
 
-        let parent_tty = String::from_utf8_lossy(&output);
+        let parent_tty = output_str.trim();
         let child_tty = string.trim();
         println!("parent: {}, child: {}", parent_tty, child_tty);
 
         assert!(child_tty != "");
         assert!(child_tty != parent_tty);
 
-        let mut parent_tty_dir: Vec<&str> = parent_tty.split("/").collect();
-        let mut child_tty_dir: Vec<&str> = child_tty.split("/").collect();
+        // only compare if parent is tty
+        // travis runs the tests without tty
+        if parent_tty != "not a tty" {
+            let mut parent_tty_dir: Vec<&str> = parent_tty.split("/").collect();
+            let mut child_tty_dir: Vec<&str> = child_tty.split("/").collect();
 
-        parent_tty_dir.pop();
-        child_tty_dir.pop();
+            parent_tty_dir.pop();
+            child_tty_dir.pop();
 
-        assert_eq!(parent_tty_dir, child_tty_dir);
+            assert_eq!(parent_tty_dir, child_tty_dir);
+        }
     } else {
         let cmd = ffi::CString::new("tty").unwrap();
         let mut args: Vec<*const libc::c_char> = Vec::with_capacity(1);

--- a/tests/it_fork_with_new_pty.rs
+++ b/tests/it_fork_with_new_pty.rs
@@ -28,6 +28,7 @@ fn it_fork_with_new_pty() {
 
         let parent_tty = String::from_utf8_lossy(&output);
         let child_tty = string.trim();
+        println!("parent: {}, child: {}", parent_tty, child_tty);
 
         assert!(child_tty != "");
         assert!(child_tty != parent_tty);

--- a/tests/it_fork_with_new_pty.rs
+++ b/tests/it_fork_with_new_pty.rs
@@ -4,11 +4,8 @@ extern crate errno;
 
 use self::pty::prelude::*;
 
-use std::ffi;
-
 use std::io::prelude::*;
 use std::process::{Command, Stdio};
-use std::ptr;
 use std::string::String;
 
 #[test]
@@ -45,15 +42,6 @@ fn it_fork_with_new_pty() {
             assert_eq!(parent_tty_dir, child_tty_dir);
         }
     } else {
-        let cmd = ffi::CString::new("tty").unwrap();
-        let mut args: Vec<*const libc::c_char> = Vec::with_capacity(1);
-
-        args.push(cmd.as_ptr());
-        args.push(ptr::null());
-        unsafe {
-            if libc::execvp(cmd.as_ptr(), args.as_mut_ptr()).eq(&-1) {
-                panic!("{}: {}", cmd.to_string_lossy(), self::errno::errno());
-            }
-        }
+        Command::new("tty").status().expect("could not execute tty");
     }
 }

--- a/tests/it_fork_with_new_pty.rs
+++ b/tests/it_fork_with_new_pty.rs
@@ -29,7 +29,6 @@ fn it_fork_with_new_pty() {
 
         let parent_tty = output_str.trim();
         let child_tty = string.trim();
-        println!("parent: {}, child: {}", parent_tty, child_tty);
 
         assert!(child_tty != "");
         assert!(child_tty != parent_tty);


### PR DESCRIPTION
As noted in [this issue](https://github.com/hibariya/pty-rs/issues/14) `it_can_read_write` did not correctly call bash. Also, it did not check the output of `echo readme!` but instead just read back what it sent to the process. This PR fixes that and also:

- it_fork_with_new_pty requires that the parent is a tty. When running the tests on travis that is not the case. Now the test checks for the string `not a tty` and does not run the last check
- replaced the `as_ptr()` in all tests/examples and documentation, because it was suffering a early freeing of the memory (as noted in the [documentation of as_ptr()](https://doc.rust-lang.org/beta/std/ffi/struct.CString.html#method.as_ptr)). I replaced it with `std::process::command::new` as the examples/tests don't require to run the `libc:execvp` directly
- the output of `tty` of the parent was still having a newline. Added `trim()`